### PR TITLE
Remove artic specific primer schemes and ONT/nanopolish

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,9 @@ For production use at large scale, where you will run the workflow many times, y
 Alternatively you can avoid just the cloning of the scheme repository to remain on a fixed revision of it over time by passing --schemeRepoURL /path/to/own/clone/of/github.com/artic-network/artic-ncov2019. This removes any internet access from the workflow except for the optional upload steps.
 
 ##### Nanopore
-###### Nanopolish
-`nextflow run connor-lab/ncov2019-artic-nf [-profile conda,singularity,docker,slurm,lsf] --nanopolish --prefix "output_file_prefix" --basecalled_fastq /path/to/directory --fast5_pass /path/to/directory --sequencing_summary /path/to/sequencing_summary.txt`
 
 ###### Medaka
- `nextflow run connor-lab/ncov2019-artic-nf [-profile conda,singularity,docker,slurm,lsf] --medaka --prefix "output_file_prefix" --basecalled_fastq /path/to/directory --fast5_pass /path/to/directory --sequencing_summary /path/to/sequencing_summary.txt`
+ `nextflow run connor-lab/ncov2019-artic-nf [-profile conda,singularity,docker,slurm,lsf] --medaka --prefix "output_file_prefix" --basecalled_fastq /path/to/directory`
 
 #### Installation
 An up-to-date version of Nextflow is required because the pipeline is written in DSL2. Following the instructions at https://www.nextflow.io/ to download and install Nextflow should get you a recent-enough version. 

--- a/bin/type_vcf.py
+++ b/bin/type_vcf.py
@@ -23,7 +23,7 @@ def parse_args(args=None):
     parser.add_argument('-af', '--allele_freq_thresh', type=float, dest="ALLELE_FREQ_THRESH", default=0, help="Only output variants where allele frequency greater than this number (default: 0).")
     parser.add_argument('-dp', '--minimum_depth', type=int, dest="MIN_DEPTH", default=0, help="Only output variants where overall read depth is greater than this number (default: 0).")
     infile = parser.add_mutually_exclusive_group(required=True)
-    infile.add_argument('-v', '--vcf', dest='VCF_IN', required=False, help="Input VCF file from either ARTIC pipeline (Nanopolish or Medaka).")
+    infile.add_argument('-v', '--vcf', dest='VCF_IN', required=False, help="Input VCF file from either ARTIC pipeline (Medaka).")
     infile.add_argument('-t', '--tab', dest='TSV_IN', required=False, help="Input iVar tsv file.")
     parser.add_argument('GFF_IN', help="Annotation GFF3 file.")
     parser.add_argument('REF_IN', help="Reference fasta file.")

--- a/conf/base.config
+++ b/conf/base.config
@@ -12,17 +12,13 @@ params{
     gff = false
     profile = false
 
-    // Repo to download your primer scheme from
-    schemeRepoURL = 'https://github.com/artic-network/primer-schemes.git'
-
-    // Directory within schemeRepoURL that contains primer schemes
-    schemeDir = 'primer-schemes'
-
+    // Absolute path containing the primer schemes
+    // e.g. <schemeDir>/<scheme>/<schemeVersion>
+    schemeDir = ''
     // Scheme name
-    scheme = 'nCoV-2019'
-
+    scheme = ''
     // Scheme version
-    schemeVersion = 'V3'
+    schemeVersion = ''
 
     // Run experimental medaka pipeline? Specify in the command using "--medaka"
     medaka = false

--- a/conf/base.config
+++ b/conf/base.config
@@ -5,30 +5,22 @@ params{
     directory = false
     prefix = false
     basecalled_fastq = false
-    fast5_pass = false
-    sequencing_summary = false
-    ref = false
-    bed = false
     gff = false
     profile = false
 
-    // Absolute path containing the primer schemes
-    // e.g. <schemeDir>/<scheme>/<schemeVersion>
+    // Absolute path containing the primer schemes (e.g. /primer_schemes)
+    // e.g. <schemeDir>/<scheme>/SARS-CoV-2/<schemeVersion>
     schemeDir = ''
-    // Scheme name
+    // Scheme name (e.g. ARTIC)
     scheme = ''
-    // Scheme version
+    // Scheme version (e.g. V4)
     schemeVersion = ''
 
-    // Run experimental medaka pipeline? Specify in the command using "--medaka"
+    // Run ONT/medaka pipeline
     medaka = false
 
     // Run Illumina pipeline
     illumina = false
- 
-    // Run nanopolish pipeline
-    nanopolish = false
-
 }
 
 

--- a/conf/gls.config
+++ b/conf/gls.config
@@ -2,7 +2,7 @@
 executor {
       workDir = 'gs://project-bucket/scratch' // <- replace with your own bucket!
 
-      if ( params.medaka || params.nanopolish ){
+      if ( params.medaka ){
       process.container = 'location of artic-ncov2019-medaka container'
       }
 

--- a/main.nf
+++ b/main.nf
@@ -28,31 +28,12 @@ if ( params.illumina ) {
        println("Use --help to print help")
        System.exit(1)
    }
-   if ( (params.bed && ! params.ref) || (!params.bed && params.ref) ) {
-       println("--bed and --ref must be supplied together")
-       System.exit(1)
-   }
-} else if ( params.nanopolish ) {
-   if (! params.basecalled_fastq ) {
-       println("Please supply a directory containing basecalled fastqs with --basecalled_fastq. This is the output directory from guppy_barcoder or guppy_basecaller - usually fastq_pass. This can optionally contain barcodeXX directories, which are auto-detected.")
-   }
-   if (! params.fast5_pass ) {
-       println("Please supply a directory containing fast5 files with --fast5_pass (this is the fast5_pass directory)")
-   }
-   if (! params.sequencing_summary ) {
-       println("Please supply the path to the sequencing_summary.txt file from your run with --sequencing_summary")
-       System.exit(1)
-   }
-   if ( params.bed || params.ref ) {
-       println("ivarBed and alignerRefPrefix only work in illumina mode")
-       System.exit(1)
-   }
 } else if ( params.medaka ) {
    if (! params.basecalled_fastq ) {
        println("Please supply a directory containing basecalled fastqs with --basecalled_fastq. This is the output directory from guppy_barcoder or guppy_basecaller - usually fastq_pass. This can optionally contain barcodeXX directories, which are auto-detected.")
    }
 } else {
-       println("Please select a workflow with --nanopolish, --illumina or --medaka, or use --help to print help")
+       println("Please select a workflow with --illumina or --medaka, or use --help to print help")
        System.exit(1)
 }
 
@@ -115,7 +96,7 @@ workflow {
    }
 
    main:
-     if ( params.nanopolish || params.medaka ) {
+     if ( params.medaka ) {
          articNcovNanopore(ch_fastqDirs)
      } else if ( params.illumina ) {
          if ( params.cram ) {
@@ -125,7 +106,7 @@ workflow {
             ncovIllumina(ch_filePairs)
          }
      } else {
-         println("Please select a workflow with --nanopolish, --illumina or --medaka")
+         println("Please select a workflow with --illumina or --medaka")
      }
      
 }

--- a/modules/artic.nf
+++ b/modules/artic.nf
@@ -1,23 +1,5 @@
 // ARTIC processes
 
-process articDownloadScheme{
-    tag params.schemeRepoURL
-
-    label 'internet'
-
-    publishDir "${params.outdir}/${task.process.replaceAll(":","_")}", pattern: "scheme", mode: "copy"
-
-    output:
-    path "${params.schemeDir}/${params.scheme}/${params.schemeVersion}/*.reference.fasta" , emit: reffasta
-    path "${params.schemeDir}/${params.scheme}/${params.schemeVersion}/*.primer.bed" , emit: bed
-    path "${params.schemeDir}" , emit: scheme
-
-    script:
-    """
-    git clone ${params.schemeRepoURL} ${params.schemeDir}
-    """
-}
-
 process articGuppyPlex {
     tag { params.prefix + "-" + fastqDir }
 
@@ -49,7 +31,7 @@ process articMinIONMedaka {
     publishDir "${params.outdir}/${task.process.replaceAll(":","_")}", pattern: "${sampleName}*", mode: "copy"
 
     input:
-    tuple file(fastq), file(schemeRepo)
+    tuple file(fastq), file(scheme)
 
     output:
     file("${sampleName}*")
@@ -69,7 +51,7 @@ process articMinIONMedaka {
     if ( params.normalise ) {
     minionRunConfigBuilder.add("--normalise ${params.normalise}")
     }
-    
+
     if ( params.bwa ) {
     minionRunConfigBuilder.add("--bwa")
     } else {
@@ -83,10 +65,11 @@ process articMinIONMedaka {
     ${minionFinalConfig} \
     --medaka-model ${params.medakaModel} \
     --threads ${task.cpus} \
-    --scheme-directory ${schemeRepo} \
+    --scheme-directory ${params.schemeDir}/${params.scheme} \
     --read-file ${fastq} \
-    ${params.scheme}/${params.schemeVersion} \
+    SARS-CoV-2/${params.schemeVersion} \
     ${sampleName}
+
     """
 }
 

--- a/modules/artic.nf
+++ b/modules/artic.nf
@@ -73,55 +73,6 @@ process articMinIONMedaka {
     """
 }
 
-process articMinIONNanopolish {
-    tag { sampleName }
-
-    label 'largecpu'
-
-    publishDir "${params.outdir}/${task.process.replaceAll(":","_")}", pattern: "${sampleName}*", mode: "copy"
-
-    input:
-    tuple file(fastq), file(schemeRepo), file(fast5Pass), file(seqSummary)
-
-    output:
-    file("${sampleName}*")
-    
-    tuple sampleName, file("${sampleName}.primertrimmed.rg.sorted.bam"), emit: ptrim
-    tuple sampleName, file("${sampleName}.sorted.bam"), emit: mapped
-    tuple sampleName, file("${sampleName}.consensus.fasta"), emit: consensus_fasta
-    tuple sampleName, file("${sampleName}.pass.vcf.gz"), emit: vcf
-
-    script:
-    // Make an identifier from the fastq filename
-    sampleName = fastq.getBaseName().replaceAll(~/\.fastq.*$/, '')
-
-    // Configure artic minion pipeline
-    minionRunConfigBuilder = []
-
-    if ( params.normalise ) {
-    minionRunConfigBuilder.add("--normalise ${params.normalise}")
-    }
-    
-    if ( params.bwa ) {
-    minionRunConfigBuilder.add("--bwa")
-    } else {
-    minionRunConfigBuilder.add("--minimap2")
-    }
-
-    minionFinalConfig = minionRunConfigBuilder.join(" ")
-
-    """
-    artic minion ${minionFinalConfig} \
-    --threads ${task.cpus} \
-    --scheme-directory ${schemeRepo} \
-    --read-file ${fastq} \
-    --fast5-directory ${fast5Pass} \
-    --sequencing-summary ${seqSummary} \
-    ${params.scheme}/${params.schemeVersion} \
-    ${sampleName}
-    """
-}
-
 process articRemoveUnmappedReads {
     tag { sampleName }
 

--- a/modules/help.nf
+++ b/modules/help.nf
@@ -16,7 +16,6 @@ def printHelp() {
 
   Mandatory workflow arguments (mutually exclusive):
     --illumina                Run the Illumina workflow
-    --nanopolish              Run the Nanopore/Nanopolish workflow (https://github.com/jts/nanopolish)
     --medaka                  Run the Nanopore/Medaka workflow (https://github.com/nanoporetech/medaka)
 
   Nanopore workflow options:
@@ -26,16 +25,13 @@ def printHelp() {
       --basecalled_fastq      The output directory from guppy_barcoder or guppy_basecaller - usually fastq_pass. 
                               This can optionally contain barcodeXXX directories, which are 
                               auto-detected and analysed in parallel.
-      --fast5_pass            Directory containing fast5 files - usually fast5_pass. NOT REQUIRED FOR MEDAKA WORKFLOW.
-      --sequencing_summary    Path to sequencing_summary.txt. NOT REQUIRED FOR MEDAKA WORKFLOW.
 
     Optional:
       --outdir                Output directory (Default: ./results)
  
-      --schemeVersion         ARTIC scheme version (Default: 'V3')
-      --schemeRepoURL         Repo to download your primer scheme from (Default: 'https://github.com/artic-network/artic-ncov2019')
-      --schemeDir             Directory within schemeRepoURL that contains primer schemes (Default: 'primer_schemes')
-      --scheme                Scheme name (Default: 'nCoV-2019')
+      --schemeVersion         ARTIC scheme version
+      --schemeDir             Directory that contains primer schemes
+      --scheme                Scheme name (e.g. ARTIC)
  
       --min_length            Minimum read length for artic guppyplex (Default: 400)
       --max_length            Maximum read length for artic guppyplex (Default: 700)
@@ -58,15 +54,10 @@ def printHelp() {
     Optional:
       --outdir                Output directory (Default: ./results)
 
-      --schemeVersion         ARTIC scheme version (Default: 'V3')
-      --schemeRepoURL         Repo to download your primer scheme from (Default: 'https://github.com/artic-network/artic-ncov2019')
-      --schemeDir             Directory within schemeRepoURL that contains primer schemes (Default: 'primer_schemes')
-      --scheme                Scheme name (Default: 'nCoV-2019')
+      --schemeVersion         ARTIC scheme version
+      --schemeDir             Directory that contains primer schemes
+      --scheme                Scheme name
  
-      --bed                   Path to iVar-compatible bed file, also requires --ref
-                              Overrides --scheme* options. (Default: unset, download scheme from git)
-      --ref                   Path to iVar-compatible reference fasta file, also requires --bed 
-                              Overrides --scheme* options. (Default: unset, download scheme from git)
       --gff                   Path to annotation gff for variant consequence calling and typing. (Default: unset, typing not run unless set)
       --yaml                  Path to YAML file with typing schemes. 
                               Format: { <typing_scheme_name> : { coverage: <float>, variants: <gene_name>: <[ D614G, IHV68I ]> }}

--- a/nextflow.config
+++ b/nextflow.config
@@ -16,7 +16,7 @@ params {
 includeConfig 'conf/base.config'
 
 
-if ( params.medaka || params.nanopolish ){
+if ( params.medaka ){
     includeConfig 'conf/nanopore.config'
 }
 
@@ -30,7 +30,7 @@ if ( params.schemeDir == '' || params.scheme == '' || params.schemeVersion == ''
 
 profiles {
   conda {
-     if ( params.medaka || params.nanopolish ) {
+     if ( params.medaka ) {
        process.conda = "$baseDir/environments/nanopore/environment.yml"
 
      } else if (params.illumina) {
@@ -50,7 +50,7 @@ profiles {
     singularity.enabled = true 
     singularity.autoMounts = true
 
-    if ( params.medaka || params.nanopolish ){
+    if ( params.medaka ){
       process.container = "file:///${baseDir}/artic-ncov2019-nanopore.sif"
     } else if (params.illumina) {
       process.container = "file:///${baseDir}/artic-ncov2019-illumina.sif"

--- a/nextflow.config
+++ b/nextflow.config
@@ -24,6 +24,9 @@ if ( params.illumina ){
     includeConfig 'conf/illumina.config'
 }
 
+if ( params.schemeDir == '' || params.scheme == '' || params.schemeVersion == '' ) {
+    throw new Exception("Please, configure schemeDir, scheme and schemeVersion parameters.")
+}
 
 profiles {
   conda {

--- a/workflows/articNcovNanopore.nf
+++ b/workflows/articNcovNanopore.nf
@@ -4,11 +4,10 @@
 nextflow.preview.dsl = 2
 
 // import modules
-include {articDownloadScheme} from '../modules/artic.nf' 
-include {articGuppyPlex} from '../modules/artic.nf' 
-include {articMinIONNanopolish} from  '../modules/artic.nf' 
+include {articGuppyPlex} from '../modules/artic.nf'
+include {articMinIONNanopolish} from  '../modules/artic.nf'
 include {articMinIONMedaka} from  '../modules/artic.nf'
-include {articRemoveUnmappedReads} from '../modules/artic.nf' 
+include {articRemoveUnmappedReads} from '../modules/artic.nf'
 
 include {makeQCCSV} from '../modules/qc.nf'
 include {writeQCSummaryCSV} from '../modules/qc.nf'
@@ -21,21 +20,25 @@ include {collateSamples} from '../modules/upload.nf'
 // import subworkflows
 include {Genotyping} from './typing.nf'
 
+
 // workflow component for artic pipeline
 workflow sequenceAnalysisNanopolish {
     take:
       ch_runFastqDirs
       ch_fast5Pass
       ch_seqSummary
-    
+
     main:
-      articDownloadScheme()
+
+      ch_reffasta = Channel.fromPath( "${params.schemeDir}/${params.scheme}/SARS-CoV-2/${params.schemeVersion}/*.reference.fasta" )
+
+      SetupPrimerScheme()
       
       articGuppyPlex(ch_runFastqDirs.flatten())
 
       articMinIONNanopolish(articGuppyPlex.out.fastq
                                           .filter{ it.countFastq() > params.minReadsArticGuppyPlex }
-                                          .combine(articDownloadScheme.out.scheme)
+                                          .combine(SetupPrimerScheme.out.scheme)
                                           .combine(ch_fast5Pass)
                                           .combine(ch_seqSummary))
 
@@ -43,7 +46,7 @@ workflow sequenceAnalysisNanopolish {
 
       makeQCCSV(articMinIONNanopolish.out.ptrim
                                      .join(articMinIONNanopolish.out.consensus_fasta, by: 0)
-                                     .combine(articDownloadScheme.out.reffasta))
+                                     .combine(SetupPrimerScheme.out.reffasta))
 
       makeQCCSV.out.csv.splitCsv()
                        .unique()
@@ -62,14 +65,14 @@ workflow sequenceAnalysisNanopolish {
 
      if (params.outCram) {
         bamToCram(articMinIONNanopolish.out.ptrim.map{ it[0] } 
-                        .join (articDownloadScheme.out.reffasta.combine(ch_preparedRef.map{ it[0] })) )
+                        .join (SetupPrimerScheme.out.reffasta.combine(ch_preparedRef.map{ it[0] })) )
 
       }
 
 
     emit:
       qc_pass = collateSamples.out
-      reffasta = articDownloadScheme.out.reffasta
+      reffasta = SetupPrimerScheme.out.reffasta
       vcf = articMinIONNanopolish.out.vcf
 
 }
@@ -79,18 +82,21 @@ workflow sequenceAnalysisMedaka {
       ch_runFastqDirs
 
     main:
-      articDownloadScheme()
+
+      // prepare reference fasta
+      ch_reffasta = Channel.fromPath( "${params.schemeDir}/${params.scheme}/SARS-CoV-2/${params.schemeVersion}/*.reference.fasta" )
+      ch_scheme = Channel.fromPath( "${params.schemeDir}/${params.scheme}" )
 
       articGuppyPlex(ch_runFastqDirs.flatten())
 
       articMinIONMedaka(articGuppyPlex.out.fastq
                                       .filter{ it.countFastq() > params.minReadsArticGuppyPlex }
-                                      .combine(articDownloadScheme.out.scheme))
+                                      .combine(ch_scheme))
 
       articRemoveUnmappedReads(articMinIONMedaka.out.mapped)
 
       makeQCCSV(articMinIONMedaka.out.ptrim.join(articMinIONMedaka.out.consensus_fasta, by: 0)
-                           .combine(articDownloadScheme.out.reffasta))
+                           .combine(ch_reffasta))
 
       makeQCCSV.out.csv.splitCsv()
                        .unique()
@@ -109,12 +115,12 @@ workflow sequenceAnalysisMedaka {
 
      if (params.outCram) {
         bamToCram(articMinIONMedaka.out.ptrim.map{ it[0] } 
-                        .join (articDownloadScheme.out.reffasta.combine(ch_preparedRef.map{ it[0] })) )
+                        .join (ch_reffasta.combine(ch_preparedRef.map{ it[0] })) )
 
       }
     emit:
       qc_pass = collateSamples.out
-      reffasta = articDownloadScheme.out.reffasta
+      reffasta = ch_reffasta
       vcf = articMinIONMedaka.out.vcf
 
 }

--- a/workflows/illuminaNcov.nf
+++ b/workflows/illuminaNcov.nf
@@ -4,13 +4,12 @@
 nextflow.preview.dsl = 2
 
 // import modules
-include {articDownloadScheme } from '../modules/artic.nf' 
-include {readTrimming} from '../modules/illumina.nf' 
+include {readTrimming} from '../modules/illumina.nf'
 include {indexReference} from '../modules/illumina.nf'
-include {readMapping} from '../modules/illumina.nf' 
-include {trimPrimerSequences} from '../modules/illumina.nf' 
+include {readMapping} from '../modules/illumina.nf'
+include {trimPrimerSequences} from '../modules/illumina.nf'
 include {callVariants} from '../modules/illumina.nf'
-include {makeConsensus} from '../modules/illumina.nf' 
+include {makeConsensus} from '../modules/illumina.nf'
 include {cramToFastq} from '../modules/illumina.nf'
 
 include {makeQCCSV} from '../modules/qc.nf'
@@ -23,62 +22,23 @@ include {collateSamples} from '../modules/upload.nf'
 // import subworkflows
 include {Genotyping} from './typing.nf'
 
+
 workflow prepareReferenceFiles {
-    // Get reference fasta
-    if (params.ref) {
-      Channel.fromPath(params.ref)
-              .set{ ch_refFasta }
-    } else {
-      articDownloadScheme()
-      articDownloadScheme.out.reffasta
-                          .set{ ch_refFasta }
-    }
+    // prepare reference fasta
+    ch_refFasta = Channel.fromPath( "${params.schemeDir}/${params.scheme}/SARS-CoV-2/${params.schemeVersion}/*.reference.fasta" )
 
+    indexReference(ch_refFasta)
+    indexReference.out
+                  .set{ ch_preparedRef }
 
-    /* Either get BWA aux files from reference 
-       location or make them fresh */
-    
-    if (params.ref) {
-      // Check if all BWA aux files exist, if not, make them
-      bwaAuxFiles = []
-      refPath = new File(params.ref).getAbsolutePath()
-      new File(refPath).getParentFile().eachFileMatch( ~/.*.bwt|.*.pac|.*.ann|.*.amb|.*.sa/) { bwaAuxFiles << it }
-     
-      if ( bwaAuxFiles.size() == 5 ) {
-        Channel.fromPath( bwaAuxFiles )
-               .set{ ch_bwaAuxFiles }
-
-        ch_refFasta.combine(ch_bwaAuxFiles.collect().toList())
-                   .set{ ch_preparedRef }
-      } else {
-        indexReference(ch_refFasta)
-        indexReference.out
-                      .set{ ch_preparedRef }
-      }
-    } else {
-      indexReference(ch_refFasta)
-      indexReference.out
-                    .set{ ch_preparedRef }
-    }
-  
-    /* If bedfile is supplied, use that,
-       if not, get it from ARTIC github repo */ 
- 
-    if (params.bed ) {
-      Channel.fromPath(params.bed)
-             .set{ ch_bedFile }
-
-    } else {
-      articDownloadScheme.out.bed
-                         .set{ ch_bedFile }
-    }
+    // prepare bed
+    ch_bedFile = Channel.fromPath( "${params.schemeDir}/${params.scheme}/SARS-CoV-2/${params.schemeVersion}/*.scheme.bed" )
 
     emit:
       bwaindex = ch_preparedRef
       bedfile = ch_bedFile
       reffasta = ch_refFasta
 }
-
 
 workflow sequenceAnalysis {
     take:

--- a/workflows/illuminaNcov.nf
+++ b/workflows/illuminaNcov.nf
@@ -53,7 +53,7 @@ workflow sequenceAnalysis {
 
       trimPrimerSequences(readMapping.out.combine(ch_bedFile))
 
-      callVariants(trimPrimerSequences.out.ptrim.combine(ch_preparedRef.map{ it[0] })) 
+      callVariants(trimPrimerSequences.out.ptrim.combine(ch_preparedRef.map{ it[0] }))
 
       makeConsensus(trimPrimerSequences.out.ptrim)
 
@@ -73,10 +73,10 @@ workflow sequenceAnalysis {
 
       collateSamples(qc.pass.map{ it[0] }
                            .join(makeConsensus.out, by: 0)
-                           .join(trimPrimerSequences.out.mapped))     
+                           .join(trimPrimerSequences.out.mapped))
 
       if (params.outCram) {
-        bamToCram(trimPrimerSequences.out.mapped.map{it[0] } 
+        bamToCram(trimPrimerSequences.out.mapped.map{it[0] }
                         .join (trimPrimerSequences.out.ptrim.combine(ch_preparedRef.map{ it[0] })) )
 
       }
@@ -91,9 +91,9 @@ workflow ncovIllumina {
       ch_filePairs
 
     main:
-      // Build or download fasta, index and bedfile as required
+      // prepare fasta, index and bedfile as required
       prepareReferenceFiles()
-      
+
       // Actually do analysis
       sequenceAnalysis(ch_filePairs, prepareReferenceFiles.out.bwaindex, prepareReferenceFiles.out.bedfile)
 
@@ -105,7 +105,7 @@ workflow ncovIllumina {
           Channel.fromPath("${params.yaml}")
                  .set{ ch_typingYaml }
 
-          Genotyping(sequenceAnalysis.out.variants, ch_refGff, prepareReferenceFiles.out.reffasta, ch_typingYaml) 
+          Genotyping(sequenceAnalysis.out.variants, ch_refGff, prepareReferenceFiles.out.reffasta, ch_typingYaml)
 
       }
 }


### PR DESCRIPTION
Changes:
* remove DownloadArticScheme() and allow the pipeline to find these primers in a local path
* remove ONT/nanopolish workflow as we do not use it and we do not have tests for it


ONT/Medaka:
```
(base) root@933f605da928:/medaka# nextflow run /ncov2019-artic-nf       --medaka       --medakaModel r941_min_high_g351       --prefix ont_short       --basecalled_fastq b833399a-4d49-4d00-abdb-39d5086a5a0d       --outdir ncov_output       --schemeDir /primer_schemes       --scheme ARTIC       --schemeVersion V3   -c /ncov-nanopore.config
N E X T F L O W  ~  version 21.10.6
Launching `/ncov2019-artic-nf/main.nf` [naughty_colden] - revision: 05d95068f5
WARN: DSL 2 PREVIEW MODE IS DEPRECATED - USE THE STABLE VERSION INSTEAD -- Read more at https://www.nextflow.io/docs/latest/dsl2.html#dsl2-migration-notes
[ca/49fdbd] Submitted process > articNcovNanopore:sequenceAnalysisMedaka:articGuppyPlex (ont_short-b833399a-4d49-4d00-abdb-39d5086a5a0d)
[50/e72e63] Submitted process > articNcovNanopore:sequenceAnalysisMedaka:articMinIONMedaka (ont_short_b833399a-4d49-4d00-abdb-39d5086a5a0d)
[5e/d0e5b2] Submitted process > articNcovNanopore:sequenceAnalysisMedaka:articRemoveUnmappedReads (ont_short_b833399a-4d49-4d00-abdb-39d5086a5a0d)
[c3/2fd356] Submitted process > articNcovNanopore:sequenceAnalysisMedaka:makeQCCSV (ont_short_b833399a-4d49-4d00-abdb-39d5086a5a0d)
[f6/66be90] Submitted process > articNcovNanopore:sequenceAnalysisMedaka:writeQCSummaryCSV (ont_short)                                       
[b8/10c26c] Submitted process > articNcovNanopore:sequenceAnalysisMedaka:collateSamples (ont_short_b833399a-4d49-4d00-abdb-39d5086a5a0d)
```

Illumina:
```
N E X T F L O W  ~  version 21.10.6
Launching `/ncov2019-artic-nf/main.nf` [disturbed_mestorf] - revision: 05d95068f5
WARN: DSL 2 PREVIEW MODE IS DEPRECATED - USE THE STABLE VERSION INSTEAD -- Read more at https://www.nextflow.io/docs/latest/dsl2.html#dsl2-migration-notes
[03/d64c33] Submitted process > ncovIllumina:sequenceAnalysis:readTrimming (9729bce7-f0a9-4617-b6e0-6145307741d1)
[f8/ab0da3] Submitted process > ncovIllumina:prepareReferenceFiles:indexReference (SARS-CoV-2.reference.fasta)
[2d/5521b6] Submitted process > ncovIllumina:sequenceAnalysis:readMapping (9729bce7-f0a9-4617-b6e0-6145307741d1)
[1c/28332c] Submitted process > ncovIllumina:sequenceAnalysis:trimPrimerSequences (9729bce7-f0a9-4617-b6e0-6145307741d1)
[75/eaf67f] Submitted process > ncovIllumina:sequenceAnalysis:makeConsensus (9729bce7-f0a9-4617-b6e0-6145307741d1)
[7a/18cbfa] Submitted process > ncovIllumina:sequenceAnalysis:callVariants (9729bce7-f0a9-4617-b6e0-6145307741d1)
[6e/5ac139] Submitted process > ncovIllumina:sequenceAnalysis:makeQCCSV (9729bce7-f0a9-4617-b6e0-6145307741d1)
[53/92b826] Submitted process > ncovIllumina:sequenceAnalysis:collateSamples (9729bce7-f0a9-4617-b6e0-6145307741d1)
[61/bbbcc4] Submitted process > ncovIllumina:sequenceAnalysis:writeQCSummaryCSV (illumina_short)
```