### PR TITLE
Pin ivar patch version

### DIFF
--- a/environments/illumina/environment.yml
+++ b/environments/illumina/environment.yml
@@ -13,6 +13,6 @@ dependencies:
   - samtools=1.10
   - bcftools=1.10
   - trim-galore=0.6.5
-  - ivar=1.3
+  - ivar=1.3.1
   - pyvcf=0.6.8
   - pyyaml=5.3.1

--- a/environments/illumina/environment.yml
+++ b/environments/illumina/environment.yml
@@ -4,15 +4,19 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - python=3
-  - biopython=1.74
+  - python=3.6
+  - biopython=1.79
   - libxcb
-  - matplotlib=3.3.3
-  - pandas=0.23.0=py36_1
+  - matplotlib=3.3.4
+  - pandas=1.1.5
   - bwa=0.7.17=pl5.22.0_2
-  - samtools=1.10
-  - bcftools=1.10
+  - samtools=1.15
+  - bcftools=1.15
   - trim-galore=0.6.5
   - ivar=1.3.1
   - pyvcf=0.6.8
   - pyyaml=5.3.1
+  - openjdk=11.0.8
+  - nextflow=21.10.6
+  - pip:
+    - click==7.1.2

--- a/environments/nanopore/environment.yml
+++ b/environments/nanopore/environment.yml
@@ -1,12 +1,21 @@
 name: artic
 channels:
-    - epi2melabs
-    - bioconda
-    - conda-forge
-    - defaults
+  - epi2melabs
+  - bioconda
+  - conda-forge
+  - defaults
 dependencies:
-    - aplanat=0.5.4
-    - fastcat=0.3.6
-    - np-artic=1.3.0=py_11
-    - pomoxis=0.3.6
-    - setuptools=59.8.0
+  - aplanat=0.5.4
+  - biopython=1.78
+  - matplotlib=3.6.2
+  - pandas=1.2.4
+  - samtools=1.12
+  - libxcb
+  - fastcat=0.3.6
+  - np-artic=1.3.0=py_11
+  - pomoxis=0.3.6
+  - setuptools=59.8.0
+  - openjdk=11.0.8
+  - nextflow=21.10.6
+  - pip:
+    - click==7.1.2


### PR DESCRIPTION
Changes:
* pin ivar to 1.3.1 as 1.3.2 has serious performance issues
* copy the dependencies is `environments/extras.yml` to the illumina / ont environments so that our docker images are based on 1 single environment yml. The versions are pinned based on release: 4.0.0.